### PR TITLE
maven-compiler-plugin added for fixing "Error:java: release version 5…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,15 @@
 			<plugins>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.8.1</version>
+					<configuration>
+						<release>11</release>
+					</configuration>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>2.18</version>
 					<dependencies>


### PR DESCRIPTION
I opened this template on Intellij and found this error "Error:java: release version 5 not supported" while building. (I was using JDK 13)
By adding maven-compiler-plugin, this project can be sucessful built on Intellij.